### PR TITLE
Updated for core24 and GNOME 46

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -56,6 +56,8 @@ parts:
     meson-parameters:
       - --prefix=/usr
       - -Dloaders=glycin-heif,glycin-image-rs,glycin-svg
+    build-packages:
+      - libclang-18-dev
 
   loupe:
     after: [ rustup, heif ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,7 +53,9 @@ parts:
       - CARGO_HOME: $CRAFT_STAGE/usr/share/rust
       - CARGO_BUILD_JOBS: $CRAFT_PARALLEL_BUILD_COUNT
     meson-parameters:
-      - --prefix=/usr
+      - --prefix=/snap/loupe/current/usr
+    organize:
+       snap/loupe/current/usr: usr
 
   loupe:
     after: [ rustup, heif ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -44,7 +44,8 @@ parts:
   glycin-loaders:
     after: [rustup, heif]
     plugin: meson
-    source: https://download.gnome.org/sources/glycin-loaders/0.1/glycin-loaders-0.1.1.tar.xz
+    source: https://gitlab.gnome.org/sophie-h/glycin.git
+    source-tag: '1.0.1'
 # ext:updatesnap
 #   version-format:
 #     ignore: true
@@ -54,6 +55,7 @@ parts:
       - CARGO_BUILD_JOBS: $CRAFT_PARALLEL_BUILD_COUNT
     meson-parameters:
       - --prefix=/usr
+      - -Dloaders=glycin-heif,glycin-image-rs,glycin-svg
 
   loupe:
     after: [ rustup, heif ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,6 @@ parts:
     override-pull: |
       craftctl default
       sed -i.bak 's|2.12.0|2.12|g' meson.build
-    build-snaps: [ gnome-46-2404-sdk/latest/edge, gnome-46-2404/latest/edge ] #Only needed until these snaps land in stable
 
   libraries:
     plugin: nil

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: loupe
-base: core22
+base: core24
 adopt-info: loupe
 grade: stable
 confinement: strict
@@ -60,11 +60,11 @@ parts:
     # See 'snapcraft plugins'
     plugin: meson
     source: https://gitlab.gnome.org/GNOME/loupe.git
-    source-tag: '45.3'
+    source-tag: '46.2'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: 46.0
+#     lower-than: 47.0
     build-environment:
       - RUSTUP_HOME: $CRAFT_STAGE/usr/share/rust
       - CARGO_HOME: $CRAFT_STAGE/usr/share/rust
@@ -80,13 +80,14 @@ parts:
     override-pull: |
       craftctl default
       sed -i.bak 's|2.12.0|2.12|g' meson.build
+    build-snaps: [ gnome-46-2404-sdk/latest/edge, gnome-46-2404/latest/edge ] #Only needed until these snaps land in stable
 
   libraries:
     plugin: nil
     stage-packages:
       - libx265-199
       - libde265-0
-      - libdav1d5
+      - libdav1d7
       - libaom3
       - libnuma1
     prime:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,9 +53,7 @@ parts:
       - CARGO_HOME: $CRAFT_STAGE/usr/share/rust
       - CARGO_BUILD_JOBS: $CRAFT_PARALLEL_BUILD_COUNT
     meson-parameters:
-      - --prefix=/snap/loupe/current/usr
-    organize:
-       snap/loupe/current/usr: usr
+      - --prefix=/usr
 
   loupe:
     after: [ rustup, heif ]


### PR DESCRIPTION
This is a WIP branch, it builds against gnome-46-2404-sdk and depends on the experimental gnome extension for core24

To build:
```
SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 snapcraft 
```