### PR TITLE
Fix build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -Doptimization=3
       - -Ddebug=false
-
+      - -DWITH_EXAMPLES=false
   glycin-loaders:
     after: [heif]
     plugin: meson


### PR DESCRIPTION
The snap currently doesn't build because libheif tries to find jconfig.h in the wrong folder. Since that is needed only for the examples, this can be easily fixed removing them from the build.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Built the package, installed it, launched with "snap run loupe", and opened a picture.

**Test Configuration**:

* OS (please include version):
* Any other relevant environment information:

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

